### PR TITLE
Update attributemappingsconcept.md

### DIFF
--- a/doc_source/attributemappingsconcept.md
+++ b/doc_source/attributemappingsconcept.md
@@ -46,6 +46,8 @@ The following table lists all AWS SSO attributes that are supported and that can
 | $\{user:name\} | 
 | $\{user:preferredUsername\} | 
 | $\{user:subject\} | 
+| $\{user:groups\} | 
+
 
 ## Default Mappings<a name="defaultattributemappings"></a>
 


### PR DESCRIPTION
added user.groups attribute, aws sso can manage his own user and group base without any AD, the attribute  can be used to map aws sso groups to external services. The attribute is not expecting the group by name, instead it uses the group ID

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
