### PR TITLE
expose the groups attribute in your documentation

### DIFF
--- a/doc_source/attributemappingsconcept.md
+++ b/doc_source/attributemappingsconcept.md
@@ -52,6 +52,7 @@ The following table lists all AWS SSO attributes that are supported and that can
 | $\{user:name\} | 
 | $\{user:preferredUsername\} | 
 | $\{user:subject\} | 
+| $\{user:groups\} | 
 
 ## Supported external identity provider attributes<a name="supportedidpattributes"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I'd like to point out that the user:groups attribute exists within AWS SSO and can be used in the SAML assertion that is sent to service providers. This has helped a great deal in granting correct access to applications.

I see that it was removed via this commit, but don't see a reason as to _why_ it was removed. Should I not be using this attribute? https://github.com/awsdocs/aws-single-sign-on-user-guide/commit/212c5dd485e46b649f6bfdd85440c1422debe159


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
